### PR TITLE
Improvement for indoor scenarios

### DIFF
--- a/config/ouster.yaml
+++ b/config/ouster.yaml
@@ -8,6 +8,9 @@ real_time: false         # in a slow CPU, real_time ensures to always output to 
 points_topic: "/os1_cloud_node/points"
 imus_topic: "/os1_cloud_node/imu"
 
+# Publishers
+high_quality_publish: false   # true: Publishes the map without downsampling, can be slower. false: Publishes the downsampled map.  
+
 # Extrinsics
 estimate_extrinsics: false
 print_extrinsics: false
@@ -32,7 +35,7 @@ LiDAR_noise: 0.001
 full_rotation_time: 0.1
 min_dist: 4                # Minimum distance: doesn't use points closer than this radius
 downsample_rate: 4         # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
-downsample_prec: 0.2       # Downsampling precision: Indoors, lower values (~0.1) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
+downsample_prec: 0.5       # Downsampling precision: Indoors, lower values (~0.2) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
 
 # IMU
 imu_rate: 100              # Approximated IMU rate: only used to estimate when to start the algorithm

--- a/config/ouster.yaml
+++ b/config/ouster.yaml
@@ -31,7 +31,8 @@ offset_beginning: true     # (Usual values: Velodyne = false, Ouster = true, HES
 LiDAR_noise: 0.001
 full_rotation_time: 0.1
 min_dist: 4                # Minimum distance: doesn't use points closer than this radius
-ds_rate: 4                 # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
+downsample_rate: 4         # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
+downsample_prec: 0.2       # Downsampling precision: Indoors, lower values (~0.1) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
 
 # IMU
 imu_rate: 100              # Approximated IMU rate: only used to estimate when to start the algorithm

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -29,7 +29,8 @@ offset_beginning: false    # (Usual values: Velodyne = false, Ouster = true, HES
 LiDAR_noise: 0.001
 full_rotation_time: 0.1
 min_dist: 4                # Minimum distance: doesn't use points closer than this radius
-ds_rate: 4                 # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
+downsample_rate: 4         # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
+downsample_prec: 0.2       # Downsampling precision: Indoors, lower values (~0.1) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
 
 # IMU
 imu_rate: 200              # Approximated IMU rate: only used to estimate when to start the algorithm

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -6,6 +6,9 @@ real_time: false         # in a slow CPU, real_time ensures to always output to 
 points_topic: "/lidar/points"
 imus_topic: "/imu/raw"
 
+# Publishers
+high_quality_publish: false   # true: Publishes the map without downsampling, can be slower. false: Publishes the downsampled map.  
+
 # Extrinsics
 estimate_extrinsics: false
 print_extrinsics: false
@@ -30,7 +33,7 @@ LiDAR_noise: 0.001
 full_rotation_time: 0.1
 min_dist: 4                # Minimum distance: doesn't use points closer than this radius
 downsample_rate: 4         # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
-downsample_prec: 0.2       # Downsampling precision: Indoors, lower values (~0.1) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
+downsample_prec: 0.5       # Downsampling precision: Indoors, lower values (~0.2) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
 
 # IMU
 imu_rate: 200              # Approximated IMU rate: only used to estimate when to start the algorithm

--- a/config/xaloc.yaml
+++ b/config/xaloc.yaml
@@ -28,7 +28,8 @@ offset_beginning: true     # (Xaloc's value, having a modified Velodyne LiDAR dr
 LiDAR_noise: 0.001
 full_rotation_time: 0.1
 min_dist: 4
-ds_rate: 4
+downsample_rate: 4         # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
+downsample_prec: 0.5       # Downsampling precision: Indoors, lower values (~0.1) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
 
 # IMU
 imu_rate: 400

--- a/config/xaloc.yaml
+++ b/config/xaloc.yaml
@@ -6,6 +6,9 @@ real_time: true
 points_topic: "/velodyne_points"
 imus_topic: "/vectornav/IMU"
 
+# Publishers
+high_quality_publish: false   # true: Publishes the map without downsampling, can be slower. false: Publishes the downsampled map.  
+
 # Extrinsics
 estimate_extrinsics: false
 print_extrinsics: false
@@ -29,7 +32,7 @@ LiDAR_noise: 0.001
 full_rotation_time: 0.1
 min_dist: 4
 downsample_rate: 4         # Downsampling rate: results show that this one can be up to 32 and still work, try it if you need a speedup
-downsample_prec: 0.5       # Downsampling precision: Indoors, lower values (~0.1) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
+downsample_prec: 0.5       # Downsampling precision: Indoors, lower values (~0.2) work better. Outdoors, higher values (~0.5) lead to less degeneracy.
 
 # IMU
 imu_rate: 400

--- a/include/Headers/Common.hpp
+++ b/include/Headers/Common.hpp
@@ -69,7 +69,8 @@ struct Params {
     double full_rotation_time;
     double imu_rate;
 
-    int ds_rate;
+    int downsample_rate;
+    float downsample_prec;
     double min_dist;
     std::string LiDAR_type;
     

--- a/include/Headers/Common.hpp
+++ b/include/Headers/Common.hpp
@@ -71,6 +71,8 @@ struct Params {
 
     int downsample_rate;
     float downsample_prec;
+    bool high_quality_publish;
+
     double min_dist;
     std::string LiDAR_type;
     

--- a/src/Modules/Compensator.cpp
+++ b/src/Modules/Compensator.cpp
@@ -152,7 +152,7 @@
             pcl::PointCloud<full_info::Point> ds_pcl;
             pcl::VoxelGrid<full_info::Point> filter;
             filter.setInputCloud(pcl_ptr);
-            filter.setLeafSize(0.5, 0.5, 0.5);
+            filter.setLeafSize(Config.downsample_prec, Config.downsample_prec, Config.downsample_prec);
             filter.filter(ds_pcl);
             
             Points ds_points;
@@ -165,13 +165,13 @@
 
             for (int i = 0; i < points.size(); ++i) {
                 const Point& p = points[i];
-                if (0 < p.range and p.range < 4 and (256/Config.ds_rate <= 1 or i%(256/Config.ds_rate) == 0)) ds_points.push_back(p);
-                else if (4 < p.range and p.range < 6 and (64/Config.ds_rate <= 1 or i%(64/Config.ds_rate) == 0)) ds_points.push_back(p);
-                else if (6 < p.range and p.range < 9 and (32/Config.ds_rate <= 1 or i%(32/Config.ds_rate) == 0)) ds_points.push_back(p);
-                else if (9 < p.range and p.range < 12 and (16/Config.ds_rate <= 1 or i%(16/Config.ds_rate) == 0)) ds_points.push_back(p);
-                else if (12 < p.range and p.range < 22 and (8/Config.ds_rate <= 1 or i%(8/Config.ds_rate) == 0)) ds_points.push_back(p);
-                else if (22 < p.range and p.range < 30 and (4/Config.ds_rate <= 1 or i%(4/Config.ds_rate) == 0)) ds_points.push_back(p);
-                else if (30 < p.range and p.range < 50 and (2/Config.ds_rate <= 1 or i%(2/Config.ds_rate) == 0)) ds_points.push_back(p);
+                if (0 < p.range and p.range < 4 and (256/Config.downsample_rate <= 1 or i%(256/Config.downsample_rate) == 0)) ds_points.push_back(p);
+                else if (4 < p.range and p.range < 6 and (64/Config.downsample_rate <= 1 or i%(64/Config.downsample_rate) == 0)) ds_points.push_back(p);
+                else if (6 < p.range and p.range < 9 and (32/Config.downsample_rate <= 1 or i%(32/Config.downsample_rate) == 0)) ds_points.push_back(p);
+                else if (9 < p.range and p.range < 12 and (16/Config.downsample_rate <= 1 or i%(16/Config.downsample_rate) == 0)) ds_points.push_back(p);
+                else if (12 < p.range and p.range < 22 and (8/Config.downsample_rate <= 1 or i%(8/Config.downsample_rate) == 0)) ds_points.push_back(p);
+                else if (22 < p.range and p.range < 30 and (4/Config.downsample_rate <= 1 or i%(4/Config.downsample_rate) == 0)) ds_points.push_back(p);
+                else if (30 < p.range and p.range < 50 and (2/Config.downsample_rate <= 1 or i%(2/Config.downsample_rate) == 0)) ds_points.push_back(p);
                 else if (p.range > 50) ds_points.push_back(p);
             }
 

--- a/src/Utils/PointCloudProcessor.cpp
+++ b/src/Utils/PointCloudProcessor.cpp
@@ -103,8 +103,8 @@ extern struct Params Config;
             int ds_counter = 0;
 
             for (Point p : points) {
-                // Keep point if counter is multiple of ds_rate
-                bool keep_point = Config.ds_rate <= 1 or ++ds_counter%Config.ds_rate == 0; 
+                // Keep point if counter is multiple of downsample_rate
+                bool keep_point = Config.downsample_rate <= 1 or ++ds_counter%Config.downsample_rate == 0; 
                 if (keep_point and Config.min_dist < p.norm()) downsampled.push_back(p);
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,8 @@ void fill_config(ros::NodeHandle& nh) {
     nh.param<bool>("real_time", Config.real_time, true);
     nh.param<bool>("estimate_extrinsics", Config.estimate_extrinsics, false);
     nh.param<bool>("print_extrinsics", Config.print_extrinsics, false);
-    nh.param<int>("ds_rate", Config.ds_rate, 4);
+    nh.param<int>("downsample_rate", Config.downsample_rate, 4);
+    nh.param<float>("downsample_prec", Config.downsample_prec, 0.2);
     nh.param<int>("MAX_NUM_ITERS", Config.MAX_NUM_ITERS, 3);
     nh.param<std::vector<double>>("LIMITS", Config.LIMITS, std::vector<double> (23, 0.001));
     nh.param<int>("NUM_MATCH_POINTS", Config.NUM_MATCH_POINTS, 5);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,17 +88,21 @@ int main(int argc, char** argv) {
                 publish.tf(Xt2);
 
                 // Publish pointcloud used to localize
-                Points global_compensated = Xt2 * Xt2.I_Rt_L() * ds_compensated;
-                publish.pointcloud(global_compensated, true);
+                Points global_compensated = Xt2 * Xt2.I_Rt_L() * compensated;
+                Points global_ds_compensated = Xt2 * Xt2.I_Rt_L() * ds_compensated;
+                if (Config.high_quality_publish) publish.pointcloud(global_compensated, true);
+                else publish.pointcloud(global_ds_compensated, true);
+
+                // Publish updated extrinsics
+                if (Config.print_extrinsics) publish.extrinsics(Xt2);
 
             // Step 2. MAPPING
 
                 // Add updated points to map (mapping online)
                 if (Config.mapping_online) {
-                    map.add(global_compensated, t2, true);
-                    publish.pointcloud(global_compensated, false);
-                    
-                    if (Config.print_extrinsics) publish.extrinsics(Xt2);
+                    map.add(global_ds_compensated, t2, true);
+                    if (Config.high_quality_publish) publish.pointcloud(global_compensated, false);                    
+                    else publish.pointcloud(global_ds_compensated, false);                    
                 }
                 // Add updated points to map (mapping offline)
                 else if (map.hasToMap(t2)) {
@@ -108,11 +112,9 @@ int main(int argc, char** argv) {
                     Points global_full_compensated = Xt2 * Xt2.I_Rt_L() * full_compensated;
                     Points global_full_ds_compensated = comp.downsample(global_full_compensated);
 
-                    if (global_full_ds_compensated.size() < Config.MAX_POINTS2MATCH) break; 
-                    if (Config.print_extrinsics) publish.extrinsics(Xt2);
-
                     map.add(global_full_ds_compensated, t2, true);
-                    publish.pointcloud(global_full_ds_compensated, false);
+                    if (Config.high_quality_publish) publish.pointcloud(global_full_compensated, false);
+                    else publish.pointcloud(global_full_ds_compensated, false);
                 }
 
             // Step 3. ERASE OLD DATA
@@ -139,6 +141,7 @@ void fill_config(ros::NodeHandle& nh) {
     nh.param<bool>("print_extrinsics", Config.print_extrinsics, false);
     nh.param<int>("downsample_rate", Config.downsample_rate, 4);
     nh.param<float>("downsample_prec", Config.downsample_prec, 0.2);
+    nh.param<bool>("high_quality_publish", Config.high_quality_publish, false);
     nh.param<int>("MAX_NUM_ITERS", Config.MAX_NUM_ITERS, 3);
     nh.param<std::vector<double>>("LIMITS", Config.LIMITS, std::vector<double> (23, 0.001));
     nh.param<int>("NUM_MATCH_POINTS", Config.NUM_MATCH_POINTS, 5);


### PR DESCRIPTION
Seeing (literally) for the first time indoor data, I've seen it's relevant to add the ability to change the downsampling precision. Indoor scenarios have more details and open spaces tend to have repeated normals and create degenerate scenarios.

The ``downsampling_prec`` parameter is added such that the lower the value is, less spatial downsampling there is.

Results using @qpc001's data (hope you don't mind!).

### ``downsampling_prec: 0.5``
![Screenshot from 2022-02-24 23-40-37](https://user-images.githubusercontent.com/6130834/155559125-b25bbe01-a507-462a-9f23-88a799bd02fb.png)

### ``downsampling_prec: 0.1``
![Screenshot from 2022-02-24 23-40-02](https://user-images.githubusercontent.com/6130834/155559138-e85bc472-1953-406d-8137-06a7bde2a8d0.png)
 